### PR TITLE
Add optional keyword argument to control whether event is included in…

### DIFF
--- a/downtoearth/router.py
+++ b/downtoearth/router.py
@@ -52,15 +52,21 @@ class Router(object):
         route = "{}:{}".format(verb, path)
         self.add_full_route(route, delegate)
 
-    def route_request(self, event, context):
-        """Route incoming request."""
+    def route_request(self, event, context, include_event=True):
+        """Route incoming request.
+
+        Args:
+            include_event (bool, optional): include event as 'event' key in params dict
+                defaults to True
+        """
         func = self.route_map.get(event['route'])
         if not func:
             raise ValueError("{}: route not found".format(event["route"]))
         params = {}
         for param_type in self.param_order[::-1]:
             params.update(event.get(param_type, {}))
-        params['event'] = event
+        if include_event:
+            params['event'] = event
         result = func(**params)
         if result is None:
             raise NotFoundException('The resource could not be found.')


### PR DESCRIPTION
… params

The idea here is that sometimes you don't want delegates to have to take
arguments beyond that which are required. If we know that we are passing,
explicitly, all the arguments that we need, we can strip the event off and not
require the called delegates to take extra **kwargs.

This defaults to True so that we do not violate any existing contracts with
callers of the library.

The reason the option is provided on the route_request method, in lieu of the of
the router instance __init__, is so that it can be controlled per request route.
It may be that you want to include the event for some methods but not others.