### PR TITLE
Updated example runme.sh with new command syntax

### DIFF
--- a/examples/runme.sh
+++ b/examples/runme.sh
@@ -1,9 +1,13 @@
 LAMBDA_SOURCE="./lambda_handler.py"
 LAMBDA_ZIP="./dist/api-lambda.zip"
+LAMBDA_STAGE="production"
 INPUT_JSON="./api.json"
 TERRAFORM_OUTPUT="./sample.tf"
 
 zip -r $LAMBDA_ZIP $LAMBDA_SOURCE
 
-## remove flag [--deploy] to only generate terraform without deploying resources
-downtoearth $INPUT_JSON $TERRAFORM_OUTPUT --deploy
+## Use this command to deploy your terraform
+downtoearth deploy $INPUT_JSON $LAMBDA_STAGE
+
+## Use this command to only generate the terraform without deploying
+# downtoearth generate $INPUT_JSON $TERRAFORM_OUTPUT


### PR DESCRIPTION
The current runme.sh script in the example/ folder contains out-dated syntax, and will fail on first run. I've updated it to include two separate commands for either generating or deploying the example terraform.